### PR TITLE
Add `otherwise` keyword for case statements

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -206,7 +206,7 @@ function statements(trailing) {
 			repeat($.caseCase),
 			optional(tr($,'caseCase')),
 			optional(seq(
-				$.kElse,
+				choice($.kElse, $.kOtherwise),
 				optional(':'),
 				optional(tr($,'_statements'))
 			)),
@@ -1141,6 +1141,7 @@ module.exports = grammar({
 		kAbstract:         $ => /abstract/i,
 		kSealed:           $ => /seled/i,
 		kDynamic:          $ => /dynamic/i,
+		kOtherwise:        $ => /otherwise/i,
 		kOverride:         $ => /override/i,
 		kOverload:         $ => /overload/i,
 		kReintroduce:      $ => /reintroduce/i,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -866,8 +866,17 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "kElse"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "kElse"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "kOtherwise"
+                      }
+                    ]
                   },
                   {
                     "type": "CHOICE",
@@ -1879,8 +1888,17 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "kElse"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "kElse"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "kOtherwise"
+                      }
+                    ]
                   },
                   {
                     "type": "CHOICE",
@@ -9290,6 +9308,11 @@
       "value": "dynamic",
       "flags": "i"
     },
+    "kOtherwise": {
+      "type": "PATTERN",
+      "value": "otherwise",
+      "flags": "i"
+    },
     "kOverride": {
       "type": "PATTERN",
       "value": "override",
@@ -9629,5 +9652,6 @@
   "precedences": [],
   "externals": [],
   "inline": [],
-  "supertypes": []
+  "supertypes": [],
+  "reserved": {}
 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -595,6 +595,10 @@
           "named": true
         },
         {
+          "type": "kOtherwise",
+          "named": true
+        },
+        {
           "type": "kSpecialize",
           "named": true
         },
@@ -8288,7 +8292,8 @@
   },
   {
     "type": "comment",
-    "named": true
+    "named": true,
+    "extra": true
   },
   {
     "type": "identifier",
@@ -8687,6 +8692,10 @@
     "named": true
   },
   {
+    "type": "kOtherwise",
+    "named": true
+  },
+  {
     "type": "kOut",
     "named": true
   },
@@ -8916,6 +8925,7 @@
   },
   {
     "type": "pp",
-    "named": true
+    "named": true,
+    "extra": true
   }
 ]

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -18,6 +18,11 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
+typedef struct TSLanguageMetadata {
+  uint8_t major_version;
+  uint8_t minor_version;
+  uint8_t patch_version;
+} TSLanguageMetadata;
 #endif
 
 typedef struct {
@@ -26,10 +31,11 @@ typedef struct {
   bool inherited;
 } TSFieldMapEntry;
 
+// Used to index the field and supertype maps.
 typedef struct {
   uint16_t index;
   uint16_t length;
-} TSFieldMapSlice;
+} TSMapSlice;
 
 typedef struct {
   bool visible;
@@ -79,6 +85,12 @@ typedef struct {
   uint16_t external_lex_state;
 } TSLexMode;
 
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+  uint16_t reserved_word_set_id;
+} TSLexerMode;
+
 typedef union {
   TSParseAction action;
   struct {
@@ -93,7 +105,7 @@ typedef struct {
 } TSCharacterRange;
 
 struct TSLanguage {
-  uint32_t version;
+  uint32_t abi_version;
   uint32_t symbol_count;
   uint32_t alias_count;
   uint32_t token_count;
@@ -109,13 +121,13 @@ struct TSLanguage {
   const TSParseActionEntry *parse_actions;
   const char * const *symbol_names;
   const char * const *field_names;
-  const TSFieldMapSlice *field_map_slices;
+  const TSMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSLexMode *lex_modes;
+  const TSLexerMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -129,15 +141,23 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
+  const char *name;
+  const TSSymbol *reserved_words;
+  uint16_t max_reserved_word_set_size;
+  uint32_t supertype_count;
+  const TSSymbol *supertype_symbols;
+  const TSMapSlice *supertype_map_slices;
+  const TSSymbol *supertype_map_entries;
+  TSLanguageMetadata metadata;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
   uint32_t index = 0;
   uint32_t size = len - index;
   while (size > 1) {
     uint32_t half_size = size / 2;
     uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
+    const TSCharacterRange *range = &ranges[mid_index];
     if (lookahead >= range->start && lookahead <= range->end) {
       return true;
     } else if (lookahead > range->end) {
@@ -145,7 +165,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }
     size -= half_size;
   }
-  TSCharacterRange *range = &ranges[index];
+  const TSCharacterRange *range = &ranges[index];
   return (lookahead >= range->start && lookahead <= range->end);
 }
 


### PR DESCRIPTION
In the Free Pascal manual: https://www.freepascal.org/docs-html/current/ref/refsu56.html#x166-19000013.2.2

---

I found code in the wild for Free Pascal that uses `otherwise` in a case statement. Here is a small example:

```
program testotherwise;

var
  A : Integer;
begin
  A := 2;
  case A of
     1 :
       writeln('OK');
     otherwise
       writeln('WRONG');
  end;
end.
```

I don't see it mentioned in Delphi documentation: https://docwiki.embarcadero.com/RADStudio/Sydney/en/Declarations_and_Statements_(Delphi)#Case_Statements . Since I don't have Delphi or Windows installed, the best I can do is test with Delphi mode in Free Pascal and it worked fine.

I noticed that the tree sitter parser raised an ERROR in the parse tree when it hit this type of code, seeing this with an Emacs mode I scrapped together. (https://github.com/bolsen/pascal-ts-mode) For emacs tree-sitter, I notice that it stops highlighting when there is an ERROR, until it picks up again for some reason.